### PR TITLE
Get liquidity

### DIFF
--- a/src/markets.rs
+++ b/src/markets.rs
@@ -274,10 +274,10 @@ mod tests {
 		}
 	}
 
-	// mod init_tests;
-	// mod market_order_tests;
-	// mod binary_order_matching_tests;
-	// mod categorical_market_tests;
-	// mod market_resolution_tests;
+	mod init_tests;
+	mod market_order_tests;
+	mod binary_order_matching_tests;
+	mod categorical_market_tests;
+	mod market_resolution_tests;
 	mod claim_earnings_tests;
 }

--- a/src/markets.rs
+++ b/src/markets.rs
@@ -152,7 +152,7 @@ impl Markets {
 		let market = self.active_markets.get_mut(&market_id).unwrap();
 		assert_eq!(market.resoluted, true);
 		
-		let claimable = market.get_claimable(account_id.to_string());	
+		let claimable = market.get_claimable(account_id.to_string());
 		market.delete_orders_for(account_id.to_string());
 
 		self.add_balance(claimable);
@@ -278,6 +278,6 @@ mod tests {
 	// mod market_order_tests;
 	// mod binary_order_matching_tests;
 	// mod categorical_market_tests;
-	mod market_resolution_tests;
-	// mod claim_earnings_tests;
+	// mod market_resolution_tests;
+	mod claim_earnings_tests;
 }

--- a/src/markets.rs
+++ b/src/markets.rs
@@ -98,9 +98,9 @@ impl Markets {
 		let from = env::predecessor_account_id();
 		let market = self.active_markets.get_mut(&market_id).unwrap();
 		assert_eq!(market.resoluted, false);
-		let order_location = format!("{outcome_id}::{price_per_share}::{order_id}", outcome_id=outcome, price_per_share=price, order_id=order_id);
 		let mut orderbook = market.orderbooks.get_mut(&outcome).unwrap();
-		assert!(!orderbook.orders_by_user.get(&order_location).is_none(), "can only cancel orders owned by user");
+		let order = orderbook.open_orders.get(&order_id).unwrap();
+		assert!(from == order.creator);
 		orderbook.remove_order(order_id);
     }
 
@@ -132,13 +132,13 @@ impl Markets {
 		self.fdai_in_protocol= self.fdai_outside_escrow - amount as u128;
 	}
 
-	pub fn get_open_orders(&self, market_id: u64, outcome: u64, from: String) -> &HashMap<u128, Order> {
+	pub fn get_open_orders(&self, market_id: u64, outcome: u64) -> &HashMap<u128, Order> {
 		let market = self.active_markets.get(&market_id).unwrap();
 		let orderbook = market.orderbooks.get(&outcome).unwrap();
 		return &orderbook.open_orders;
 	}
 	
-	pub fn get_filled_orders(&self, market_id: u64, outcome: u64, from: String) -> &HashMap<u128, Order> {
+	pub fn get_filled_orders(&self, market_id: u64, outcome: u64) -> &HashMap<u128, Order> {
 		let market = self.active_markets.get(&market_id).unwrap();
 		let orderbook = market.orderbooks.get(&outcome).unwrap();
 		return &orderbook.filled_orders;
@@ -279,5 +279,5 @@ mod tests {
 	// mod binary_order_matching_tests;
 	// mod categorical_market_tests;
 	mod market_resolution_tests;
-	mod claim_earnings_tests;
+	// mod claim_earnings_tests;
 }

--- a/src/markets.rs
+++ b/src/markets.rs
@@ -45,7 +45,7 @@ impl Markets {
 		let from = env::predecessor_account_id();
 		let can_claim = self.fdai_balances.get(&from).is_none();
 		assert!(can_claim, "user has already claimed fdai");
-		
+
 		let claim_amount = 100 * self.dai_token();
 		self.fdai_balances.insert(from, claim_amount);
 
@@ -85,7 +85,7 @@ impl Markets {
 		let from = env::predecessor_account_id();
 		let balance = self.fdai_balances.get(&from).unwrap();
 		assert!(balance >= &spend);
-		
+
 		let amount_of_shares = spend / price_per_share;
 		let rounded_spend = amount_of_shares * price_per_share;
 		let market = self.active_markets.get_mut(&market_id).unwrap();
@@ -137,7 +137,7 @@ impl Markets {
 		let orderbook = market.orderbooks.get(&outcome).unwrap();
 		return &orderbook.open_orders;
 	}
-	
+
 	pub fn get_filled_orders(&self, market_id: u64, outcome: u64) -> &HashMap<u128, Order> {
 		let market = self.active_markets.get(&market_id).unwrap();
 		let orderbook = market.orderbooks.get(&outcome).unwrap();
@@ -151,18 +151,18 @@ impl Markets {
 	pub fn claim_earnings(&mut self, market_id: u64, account_id: String) {
 		let market = self.active_markets.get_mut(&market_id).unwrap();
 		assert_eq!(market.resoluted, true);
-		
+
 		let claimable = market.get_claimable(account_id.to_string());
 		market.delete_orders_for(account_id.to_string());
 
 		self.add_balance(claimable);
 	}
 
-	pub fn get_all_markets(&self) -> &BTreeMap<u64, Market> { 
+	pub fn get_all_markets(&self) -> &BTreeMap<u64, Market> {
 		return &self.active_markets;
 	}
 
-	pub fn get_markets_by_id(&self, market_ids: Vec<u64>) -> BTreeMap<u64, &Market> { 
+	pub fn get_markets_by_id(&self, market_ids: Vec<u64>) -> BTreeMap<u64, &Market> {
 		let mut markets = BTreeMap::new();
 		for market_id in market_ids {
 			markets.insert(market_id, self.active_markets.get(&market_id).unwrap());
@@ -170,7 +170,7 @@ impl Markets {
 		return markets;
 	}
 
-	pub fn get_specific_markets(&self, market_ids: Vec<u64>) -> BTreeMap<u64, &Market> { 
+	pub fn get_specific_markets(&self, market_ids: Vec<u64>) -> BTreeMap<u64, &Market> {
 		let mut markets = BTreeMap::new();
 		for market_id in 0..market_ids.len() {
 			markets.insert(market_id as u64, self.active_markets.get(&(market_id as u64)).unwrap());
@@ -209,7 +209,7 @@ impl Default for Markets {
 			creator: "flux-dev".to_string(),
 			active_markets: BTreeMap::new(),
 			nonce: 0,
-			fdai_balances: HashMap::new(),	
+			fdai_balances: HashMap::new(),
 			fdai_circulation: 0,
 			fdai_in_protocol: 0,
 			fdai_outside_escrow: 0,
@@ -227,15 +227,15 @@ mod tests {
 
 	fn alice() -> String {
 		return "alice.near".to_string();
-	} 
+	}
 
 	fn carol() -> String {
 		return "carol.near".to_string();
-	} 
+	}
 
 	fn bob() -> String {
 		return "bob.near".to_string();
-	} 
+	}
 
 	fn empty_string() -> String {
 		return "".to_string();
@@ -280,4 +280,5 @@ mod tests {
 	mod categorical_market_tests;
 	mod market_resolution_tests;
 	mod claim_earnings_tests;
+	mod market_depth_tests;
 }

--- a/src/markets.rs
+++ b/src/markets.rs
@@ -94,14 +94,14 @@ impl Markets {
 		self.subtract_balance(rounded_spend);
 	}
 
-	pub fn cancel_order(&mut self, market_id: u64, outcome: u64, order_id: u128, price: u128) {
+	pub fn cancel_order(&mut self, market_id: u64, outcome: u64, order_id: u128) {
 		let from = env::predecessor_account_id();
 		let market = self.active_markets.get_mut(&market_id).unwrap();
 		assert_eq!(market.resoluted, false);
 		let order_location = format!("{outcome_id}::{price_per_share}::{order_id}", outcome_id=outcome, price_per_share=price, order_id=order_id);
 		let mut orderbook = market.orderbooks.get_mut(&outcome).unwrap();
 		assert!(!orderbook.orders_by_user.get(&order_location).is_none(), "can only cancel orders owned by user");
-		orderbook.remove_order(order_id, price);
+		orderbook.remove_order(order_id);
     }
 
 	pub fn resolute(&mut self, market_id: u64, winning_outcome: Option<u64>) {
@@ -132,13 +132,13 @@ impl Markets {
 		self.fdai_in_protocol= self.fdai_outside_escrow - amount as u128;
 	}
 
-	pub fn get_open_orders(&self, market_id: u64, outcome: u64, from: String) -> &BTreeMap<u128, BTreeMap<u128, Order>> {
+	pub fn get_open_orders(&self, market_id: u64, outcome: u64, from: String) -> &HashMap<u128, Order> {
 		let market = self.active_markets.get(&market_id).unwrap();
 		let orderbook = market.orderbooks.get(&outcome).unwrap();
 		return &orderbook.open_orders;
 	}
 	
-	pub fn get_filled_orders(&self, market_id: u64, outcome: u64, from: String) -> &BTreeMap<u128, BTreeMap<u128, Order>> {
+	pub fn get_filled_orders(&self, market_id: u64, outcome: u64, from: String) -> &HashMap<u128, Order> {
 		let market = self.active_markets.get(&market_id).unwrap();
 		let orderbook = market.orderbooks.get(&outcome).unwrap();
 		return &orderbook.filled_orders;
@@ -148,12 +148,12 @@ impl Markets {
 		return self.active_markets.get(&market_id).unwrap().get_claimable(from);
 	}
 
-	pub fn claim_earnings(&mut self, market_id: u64, accountId: String) {
+	pub fn claim_earnings(&mut self, market_id: u64, account_id: String) {
 		let market = self.active_markets.get_mut(&market_id).unwrap();
 		assert_eq!(market.resoluted, true);
 		
-		let claimable = market.get_claimable(accountId.to_string());	
-		market.delete_orders_for(accountId.to_string());
+		let claimable = market.get_claimable(account_id.to_string());	
+		market.delete_orders_for(account_id.to_string());
 
 		self.add_balance(claimable);
 	}
@@ -275,9 +275,9 @@ mod tests {
 	}
 
 	// mod init_tests;
-	mod market_order_tests;
+	// mod market_order_tests;
 	// mod binary_order_matching_tests;
 	// mod categorical_market_tests;
-	// mod market_resolution_tests;
-	// mod claim_earnings_tests;
+	mod market_resolution_tests;
+	mod claim_earnings_tests;
 }

--- a/src/markets.rs
+++ b/src/markets.rs
@@ -94,23 +94,14 @@ impl Markets {
 		self.subtract_balance(rounded_spend);
 	}
 
-	pub fn cancel_order(&mut self, market_id: u64, outcome: u64, order_id: u128) {
+	pub fn cancel_order(&mut self, market_id: u64, outcome: u64, order_id: u128, price: u128) {
 		let from = env::predecessor_account_id();
 		let market = self.active_markets.get_mut(&market_id).unwrap();
 		assert_eq!(market.resoluted, false);
+		let order_location = format!("{outcome_id}::{price_per_share}::{order_id}", outcome_id=outcome, price_per_share=price, order_id=order_id);
 		let mut orderbook = market.orderbooks.get_mut(&outcome).unwrap();
-
-        let orders_by_user_vec = orderbook.orders_by_user.get(&from).unwrap();
-        for i in 0..orders_by_user_vec.len() {
-            // v = [outcome, price, order_id]
-            let v: Vec<&str> = orders_by_user_vec[i].rsplit("::").collect();
-            if v[2].parse::<u128>().unwrap() == order_id {
-                let outstanding_spend = orderbook.remove_order(order_id, v[1].parse::<u128>().unwrap());
-                market.liquidity -= outstanding_spend;
-                self.add_balance(outstanding_spend);
-                return;
-            }
-        }
+		assert!(!orderbook.orders_by_user.get(&order_location).is_none(), "can only cancel orders owned by user");
+		orderbook.remove_order(order_id, price);
     }
 
 	pub fn resolute(&mut self, market_id: u64, winning_outcome: Option<u64>) {
@@ -283,10 +274,10 @@ mod tests {
 		}
 	}
 
-	mod init_tests;
+	// mod init_tests;
 	mod market_order_tests;
-	mod binary_order_matching_tests;
-	mod categorical_market_tests;
-	mod market_resolution_tests;
-	mod claim_earnings_tests;
+	// mod binary_order_matching_tests;
+	// mod categorical_market_tests;
+	// mod market_resolution_tests;
+	// mod claim_earnings_tests;
 }

--- a/src/markets/market.rs
+++ b/src/markets/market.rs
@@ -82,6 +82,7 @@ impl Market {
 			shares_to_fill = shares_fillable;
 		}
 		
+
 		for orderbook_id in orderbook_ids {
 			let orderbook = self.orderbooks.get_mut(&orderbook_id).unwrap();
 			if !orderbook.market_order.is_none() {

--- a/src/markets/market.rs
+++ b/src/markets/market.rs
@@ -101,16 +101,18 @@ impl Market {
 		let orderbook_ids = self.get_inverse_orderbook_ids(outcome);
 		for orderbook_id in orderbook_ids {
 			let orderbook = self.orderbooks.get(&orderbook_id).unwrap();
-			let market_order_optional = orderbook.market_order;
 
-			if !market_order_optional.is_none() {
-				let market_order = orderbook.open_orders.get(&market_order_optional.unwrap()).unwrap();
-				let left_to_fill = market_order.spend - market_order.filled;
-				let shares_to_fill = left_to_fill  / market_order.price_per_share;
-				if shares.is_none() || shares_to_fill < shares.unwrap() {
-					shares = Some(shares_to_fill);
-				}
-			} 
+            if let Some((market_order_price_per_share, market_order_map)) = orderbook.open_orders.iter().next() {
+                let mut left_to_fill = 0;
+                let mut shares_to_fill = 0;
+                for (_, order) in market_order_map.iter() {
+                    left_to_fill += order.spend - order.filled;
+                    shares_to_fill += left_to_fill / market_order_price_per_share;
+                }
+                if shares.is_none() || shares_to_fill < shares.unwrap() {
+                    shares = Some(shares_to_fill);
+                }
+            }
 		}
 
 		return shares.unwrap();
@@ -131,11 +133,10 @@ impl Market {
 
  		for orderbook_id in orderbook_ids {
 			let orderbook = self.orderbooks.get(&orderbook_id).unwrap();
-			let market_order_optional = orderbook.market_order;
+			let market_order_price_per_share = orderbook.market_order;
 
-			if !market_order_optional.is_none() {
-				let market_order = orderbook.open_orders.get(&market_order_optional.unwrap()).unwrap();
-				market_price -= market_order.price_per_share;
+			if !market_order_price_per_share.is_none() {
+				market_price -= market_order_price_per_share.unwrap();
 			}
 		}
 		return market_price;
@@ -168,11 +169,11 @@ impl Market {
 		let mut claimable = 0;
 
 		if invalid {
-			for (key, orderbook) in self.orderbooks.iter() {
+			for (_, orderbook) in self.orderbooks.iter() {
 				claimable += orderbook.get_spend_by(from.to_string());
 			}
 		} else {
-			for (key, orderbook) in self.orderbooks.iter() {
+			for (_, orderbook) in self.orderbooks.iter() {
 				claimable += orderbook.get_open_order_value_for(from.to_string());
 			}
 			let winning_orderbook = self.orderbooks.get(&self.winning_outcome.unwrap()).unwrap();

--- a/src/markets/market.rs
+++ b/src/markets/market.rs
@@ -101,11 +101,12 @@ impl Market {
 		let orderbook_ids = self.get_inverse_orderbook_ids(outcome);
 		for orderbook_id in orderbook_ids {
 			let orderbook = self.orderbooks.get(&orderbook_id).unwrap();
-
-            if let Some((market_order_price_per_share, market_order_map)) = orderbook.open_orders.iter().next() {
+			
+            if let Some((market_order_price_per_share, market_order_map)) = orderbook.orders_by_price.iter().next() {
                 let mut left_to_fill = 0;
                 let mut shares_to_fill = 0;
-                for (_, order) in market_order_map.iter() {
+                for (order_id, _) in market_order_map.iter() {
+					let order = orderbook.open_orders.get(&order_id).unwrap();
                     left_to_fill += order.spend - order.filled;
                     shares_to_fill += left_to_fill / market_order_price_per_share;
                 }

--- a/src/markets/market.rs
+++ b/src/markets/market.rs
@@ -92,8 +92,8 @@ impl Market {
 		}
 		spend -= shares_to_fill * market_price;
 		shares_filled += shares_to_fill;
-		
-		return self.fill_matches(outcome, spend, price_per_share, shares_filled);
+
+		return (spend, shares_filled);
 	}
 
 	pub fn get_min_shares_fillable(&self, outcome: u64) -> u128 {
@@ -114,7 +114,6 @@ impl Market {
                 }
             }
 		}
-
 		return shares.unwrap();
 	}
 

--- a/src/markets/market/orderbook.rs
+++ b/src/markets/market/orderbook.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap};
+use std::cmp;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_bindgen::{near_bindgen};
 use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
 
 pub mod order;
 pub type Order = order::Order;
@@ -11,9 +13,10 @@ pub type Order = order::Order;
 pub struct Orderbook {
 	pub root: Option<u128>,
 	pub market_order: Option<u128>,
-	pub open_orders: BTreeMap<u128, Order>,
-	pub filled_orders: BTreeMap<u128, Order>,
+	pub open_orders: BTreeMap<u128, BTreeMap<u128, Order>>,
+	pub filled_orders: BTreeMap<u128, BTreeMap<u128, Order>>,
 	pub spend_by_user: BTreeMap<String, u128>,
+	pub orders_by_user: BTreeMap<String, Vec<String>>,
 	pub nonce: u128,
 	pub outcome_id: u64
 }
@@ -24,226 +27,193 @@ impl Orderbook {
 			open_orders: BTreeMap::new(),
 			filled_orders: BTreeMap::new(),
 			spend_by_user: BTreeMap::new(),
+			orders_by_user: BTreeMap::new(),
 			market_order: None,
 			nonce: 0,
 			outcome_id: outcome,
 		}
 	}
 
+    // Grabs latest nonce
 	fn new_order_id(&mut self) -> u128 {
 		let id = self.nonce;
 		self.nonce = self.nonce + 1;
 		return id;
 	}
 
+    // Places order in orderbook
 	pub fn place_order(&mut self, from: String, outcome: u64, spend: u128, amt_of_shares: u128, price_per_share: u128, filled: u128, shares_filled: u128) {
 		let order_id = self.new_order_id();
-		let mut new_order = Order::new(from.to_string(), outcome, order_id, spend, amt_of_shares, price_per_share, filled, shares_filled);
+		let new_order = Order::new(from.to_string(), outcome, order_id, spend, amt_of_shares, price_per_share, filled, shares_filled);
 		*self.spend_by_user.entry(from.to_string()).or_insert(0) += spend;
 
-		let left_to_spend = spend - filled;
+        // If all of spend is filled, state order is fully filled
+        let left_to_spend = spend - filled;
 		if left_to_spend < 100 {
-			self.filled_orders.insert(order_id, new_order);
+			self.filled_orders.entry(price_per_share).or_insert(BTreeMap::new()).insert(order_id, new_order);
 			return;
 		}
 
-		self.set_market_order(order_id, price_per_share);
+        // If there is a remaining order, set this new order as the new market rate
+		self.set_market_order(price_per_share);
 
-		if self.root.is_none() {
-			self.root = Some(new_order.clone().id);
+        // Insert order into order map
+		self.open_orders.entry(price_per_share).or_insert(BTreeMap::new()).insert(order_id, new_order);
+
+		// Insert order into orders_by_user
+		let account_value = format!("{outcome_id}::{price_per_share}::{order_id}", outcome_id=self.outcome_id, price_per_share=price_per_share, order_id=order_id);
+		self.orders_by_user.entry(from.to_string()).or_insert(Vec::new()).push(account_value);
+	}
+
+    // Updates current market order price
+	fn set_market_order(&mut self, price_per_share: u128) {
+		let current_market_order_price = self.market_order;
+		if current_market_order_price.is_none() {
+			self.market_order = Some(price_per_share);
 		} else {
-			new_order = self.find_and_add_parent(new_order.clone());
-		}
-
-		self.open_orders.insert(order_id, new_order);
-	}
-
-	fn set_market_order(&mut self, order_id: u128, price_per_share: u128) {
-		let current_market_order_id = self.market_order;
-		if current_market_order_id.is_none() {
-			self.market_order = Some(order_id);
-		} else {
-			let current_market_order = self.open_orders.get(&current_market_order_id.unwrap()).unwrap();
-			if current_market_order.price_per_share < price_per_share {
-				self.market_order = Some(order_id);
+			if let Some((current_market_price, _ )) = self.open_orders.iter().next() {
+			    if price_per_share < *current_market_price {
+                    self.market_order = Some(price_per_share);
+                }
 			}
 		}
 	}
 
-	fn remove_market_order(&mut self) {
-		let market_order = self.open_orders.get(&self.market_order.unwrap()).unwrap();
-		if market_order.better_order_id.is_none() {
-			if market_order.worse_order_id.is_none() {
-				if market_order.parent.is_none() {
-					self.market_order = None;
-				} else {
-					self.market_order = market_order.parent;
-				}
-			} else {
-				self.market_order = market_order.worse_order_id;
-			}
-		} else {
-			self.market_order = market_order.better_order_id;
+    // Remove order from orderbook -- added price_per_share - if invalid order id passed behaviour undefined
+	pub fn remove_order(&mut self, order_id: u128, price_per_share: u128) -> u128 {
+		// Get orders at price
+		if let order_map = self.open_orders.get_mut(&price_per_share).unwrap() {
+            let order = order_map.get(&order_id).unwrap();
+            let outstanding_spend = order.spend - order.filled;
+            *self.spend_by_user.get_mut(&order.creator).unwrap() -= outstanding_spend;
+
+            // Add back to filled if eligible, remove from user map if not
+            if order.shares_filled > 0 {
+                self.filled_orders.entry(price_per_share).or_insert(BTreeMap::new()).insert(order.id, order.clone());
+            } else {
+                let order_by_user_vec = self.orders_by_user.get_mut(&order.creator).unwrap();
+                order_by_user_vec.swap_remove(order_id.try_into().unwrap());
+                if order_by_user_vec.is_empty() {
+                    self.orders_by_user.remove(&order.creator);
+                }
+            }
+
+            // Remove from order map
+            order_map.remove(&order_id);
+            if order_map.is_empty() {
+                self.open_orders.remove(&price_per_share);
+                if let Some((min_key, _ )) = self.open_orders.iter().next() {
+                    self.market_order = Some(*min_key);
+                }
+            }
+
+            return outstanding_spend;
 		}
+		// NOTE: Returning 0 now - is this safe/desirable?
+		return 0;
 	}
 
-	pub fn remove_order(&mut self, order_id: u128) -> u128 {
-		let order = self.open_orders.get_mut(&order_id).unwrap();
-		let outstanding_spend = order.spend - order.filled;
-		*self.spend_by_user.get_mut(&order.creator).unwrap() -= outstanding_spend;
-		let parent = order.parent;
-		let better_order_id = order.better_order_id;
-		let worse_order_id = order.worse_order_id;
-		if order.shares_filled > 0 {
-			self.filled_orders.insert(order.id, order.clone());
-		}
-		
-		if Some(order_id) == self.market_order {
-			self.remove_market_order();
-		}
-		// If removed order is root
-		if parent.is_none() {
-			
-			self.root = better_order_id;
-			
-			if !better_order_id.is_none() {
-				let better_order = self.open_orders.get_mut(&better_order_id.unwrap()).unwrap();
-				better_order.parent = None;
-				if !worse_order_id.is_none() {
-					self.update_and_replace_order(worse_order_id);
-				}
-			} else if !worse_order_id.is_none() {
-				self.root = worse_order_id;
-				let worse_order = self.open_orders.get_mut(&worse_order_id.unwrap()).unwrap();
-				worse_order.parent = None;
-			}
-		} 
-		else {
-			let parent = self.open_orders.get_mut(&parent.unwrap()).unwrap();
-			if parent.better_order_id == Some(order_id) {
-				parent.better_order_id = better_order_id;
-				self.update_and_replace_order(worse_order_id);
-			} else if parent.worse_order_id == Some(order_id) {
-				parent.worse_order_id = worse_order_id;
-				self.update_and_replace_order(better_order_id);
-			}
-		}
-		
-		
-		self.open_orders.remove(&order_id);
-		return outstanding_spend;
-	}
-
-	fn update_and_replace_order(&mut self, order_id: Option<u128>) {
-		if !order_id.is_none() {
-			let order = self.open_orders.get_mut(&order_id.unwrap()).unwrap().to_owned();
-			let updated_order = self.find_and_add_parent(order);
-			self.open_orders.insert(updated_order.id, updated_order);
-		}
-
-	}
-	
 	// TODO: Should catch these rounding errors earlier, right now some "dust" will be lost.
 	pub fn fill_market_order(&mut self, mut amt_of_shares_to_fill: u128) {
-		let current_order = self.open_orders.get_mut(&self.market_order.unwrap()).unwrap();
-		current_order.shares_filled += amt_of_shares_to_fill;
-		current_order.filled += amt_of_shares_to_fill * current_order.price_per_share;
-		if current_order.spend - current_order.filled < 100 { // some rounding erros here might cause some stack overflow bugs that's why this is build in.
-			self.remove_order(self.market_order.unwrap()); 
+	    let mut to_remove : Vec<(u128, u128)> = vec![];
+
+		if let Some(( _ , current_order_map)) = self.open_orders.iter_mut().next() {
+		    // Iteratively fill market orders until done
+            for (order_id, order) in current_order_map.iter_mut() {
+                if amt_of_shares_to_fill > 0 {
+                    let shares_remaining_in_order = order.amt_of_shares - order.shares_filled;
+                    let filling = cmp::min(shares_remaining_in_order, amt_of_shares_to_fill);
+
+                    order.shares_filled += filling;
+                    order.filled += filling * order.price_per_share;
+
+                    if order.spend - order.filled < 100 { // some rounding errors here might cause some stack overflow bugs that's why this is build in.
+                        to_remove.push((*order_id, order.price_per_share));
+                    }
+                    amt_of_shares_to_fill -= filling;
+                } else {
+                    break;
+                }
+            }
 		}
-	}
 
-
-	fn find_and_add_parent(&mut self, new_order: Order) -> Order {
-		let mut order_id_optional = self.root;
-		let mut parent_order = None;
-		let mut updated_order = new_order.clone();
-		
-		while parent_order.is_none() {
-			let order = self.open_orders.get(&order_id_optional.unwrap()).unwrap();
-			if order.is_better_price_than(new_order.clone()) {
-				if !order.worse_order_id.is_none() {
-					order_id_optional = order.worse_order_id;
-				} else {
-					parent_order = Some(order);
-					updated_order.parent = Some(order.id);
-				}
-			} else {
-				if !order.better_order_id.is_none() {
-					order_id_optional = order.better_order_id;
-				} else {
-					parent_order = Some(order);
-					updated_order.parent = Some(order.id);
-				}
-			}
-
+		for entry in to_remove {
+		    self.remove_order(entry.0, entry.1);
 		}
-		
-		self.add_child(parent_order.unwrap().id, updated_order.clone());
-		return updated_order;
-	}
 
-	fn add_child(&mut self, parent_id: u128, child: Order) {
-		let parent_order = self.open_orders.get_mut(&parent_id).unwrap();
-	
-		if parent_order.is_better_price_than(child.to_owned()) {
-			parent_order.worse_order_id = Some(child.id);
-		} else {
-			parent_order.better_order_id = Some(child.id)
-		}
 	}
 
 	pub fn calc_claimable_amt(&self, from: String) -> u128 {
 		let mut claimable = 0;
-		for (_, order) in self.open_orders.iter() {
-			if order.creator == from {
-				claimable += order.shares_filled * 100;
-			}
-		}
-		for (_, order) in self.filled_orders.iter() {
-			if order.creator == from {
-				claimable += order.shares_filled * 100;
-			}
+		let orders_by_user_vec = self.orders_by_user.get(&from).unwrap();
+
+        // v = [outcome, price_per_share, order_id]
+		for i in 0..orders_by_user_vec.len() {
+		    let v: Vec<&str> = orders_by_user_vec[i].rsplit("::").collect();
+		    // Try open orders
+		    let open_order_map = self.open_orders.get(&v[1].parse::<u128>().unwrap()).unwrap();
+		    let order = open_order_map.get(&v[2].parse::<u128>().unwrap()).unwrap();
+		    claimable += order.shares_filled * 100;
+
+		    // Try filled orders
+		    let filled_order_map = self.filled_orders.get(&v[1].parse::<u128>().unwrap()).unwrap();
+		    let filled_order = filled_order_map.get(&v[2].parse::<u128>().unwrap()).unwrap();
+		    claimable += filled_order.shares_filled * 100;
 		}
 		return claimable;
 	}
 
 	pub fn delete_orders_for(&mut self, from: String) {
-		let mut open_orders_to_delete = vec![];
-		let mut filled_orders_to_delete = vec![];
-		self.spend_by_user.insert(from.to_string(), 0);
-		for (_, order) in &mut self.open_orders {
-			if order.creator == from {
-				open_orders_to_delete.push(order.id);
-			}
-		}
+	    let mut to_delete : Vec<(u128, u128)> = vec![];
+        self.spend_by_user.insert(from.to_string(), 0);
+        let orders_by_user_vec = self.orders_by_user.get(&from).unwrap();
 
-		for (_, order) in &mut self.filled_orders {
-			if order.creator == from {
-				filled_orders_to_delete.push(order.id);
-			}
-		}
+        for entry in orders_by_user_vec {
+            let v: Vec<&str> = entry.rsplit("::").collect();
+            let price_per_share = v[1].parse::<u128>().unwrap();
+            let order_id = v[2].parse::<u128>().unwrap();
+            to_delete.push((order_id, price_per_share));
+        }
 
-		for order_id in filled_orders_to_delete {
-			self.filled_orders.remove(&order_id);
-		}
-		for order_id in open_orders_to_delete {
-			self.open_orders.remove(&order_id);
-		}
+        for entry in to_delete {
+            self.remove_order(entry.0, entry.1);
+            self.remove_filled_order(entry.0, entry.1);
+        }
 	}
 
+    fn remove_filled_order(&mut self, order_id : u128, price_per_share : u128) {
+        // Get filled orders at price
+        let filled_order_map = self.filled_orders.get_mut(&price_per_share).unwrap();
+        let order = filled_order_map.get(&order_id).unwrap();
+        // Remove order from user map
+        let order_by_user_map = self.orders_by_user.get_mut(&order.creator).unwrap();
+        order_by_user_map.remove(order_id.try_into().unwrap());
+        if order_by_user_map.is_empty() {
+            self.orders_by_user.remove(&order.creator);
+        }
+        filled_order_map.remove(&order_id);
+        if filled_order_map.is_empty() {
+            self.filled_orders.remove(&price_per_share);
+        }
+        return;
+    }
+
 	pub fn get_market_order_price(&self) -> u128 {
-		let market_order = self.open_orders.get(&self.market_order.unwrap()).unwrap();
-		return market_order.price_per_share;
+		return self.market_order.unwrap();
 	}
 
 	pub fn get_open_order_value_for(&self, from: String) -> u128 {
 		let mut claimable = 0;
-		for (_, order) in self.open_orders.iter() {
-			if order.creator == from {
-				claimable += order.spend - order.filled;
-			}
-		}
+		let orders_by_user_vec = self.orders_by_user.get(&from).unwrap();
+
+        // v = [outcome, price_per_share, order_id]
+        for i in 0..orders_by_user_vec.len() {
+            let v: Vec<&str> = orders_by_user_vec[i].rsplit("::").collect();
+            // Try open orders
+            let open_order_map = self.open_orders.get(&v[1].parse::<u128>().unwrap()).unwrap();
+            let order = open_order_map.get(&v[2].parse::<u128>().unwrap()).unwrap();
+            claimable += order.shares_filled * 100;
+        }
 		return claimable;
 	}
 

--- a/src/markets/market/orderbook.rs
+++ b/src/markets/market/orderbook.rs
@@ -72,7 +72,7 @@ impl Orderbook {
 			self.market_order = Some(price_per_share);
 		} else {
 			if let Some((current_market_price, _ )) = self.open_orders.iter().next() {
-			    if price_per_share < *current_market_price {
+			    if price_per_share > *current_market_price {
                     self.market_order = Some(price_per_share);
                 }
 			}
@@ -98,13 +98,16 @@ impl Orderbook {
             }
         }
 
+
         // Remove from order map
         order_map.remove(&order_id);
         if order_map.is_empty() {
             self.open_orders.remove(&price_per_share);
             if let Some((min_key, _ )) = self.open_orders.iter().next() {
                 self.market_order = Some(*min_key);
-            }
+            } else {
+				self.market_order = None;
+			}
         }
         return outstanding_spend;
 	}

--- a/src/markets/tests/binary_order_matching_tests.rs
+++ b/src/markets/tests/binary_order_matching_tests.rs
@@ -9,12 +9,12 @@ fn simplest_binary_order_matching_test() {
 	contract.place_order(0, 0, 5000, 50);
 	contract.place_order(0, 1, 5000, 50);
 
-	let open_no_orders = contract.get_open_orders(0, 0, carol());
-	let open_yes_orders = contract.get_open_orders(0, 1, carol());
+	let open_no_orders = contract.get_open_orders(0, 0);
+	let open_yes_orders = contract.get_open_orders(0, 1);
 	assert_eq!(open_no_orders.len(), 0);
 	assert_eq!(open_yes_orders.len(), 0);
-	let filled_no_orders = contract.get_filled_orders(0, 0, carol());
-	let filled_yes_orders = contract.get_filled_orders(0, 1, carol());
+	let filled_no_orders = contract.get_filled_orders(0, 0);
+	let filled_yes_orders = contract.get_filled_orders(0, 1);
 	assert_eq!(filled_no_orders.len(), 1);
 	assert_eq!(filled_yes_orders.len(), 1);
 }
@@ -32,12 +32,12 @@ fn partial_binary_order_matching_test() {
 	contract.place_order(0, 1, 2750, 50);
 	contract.place_order(0, 0, 7777, 50);
 
-	let open_no_orders = contract.get_open_orders(0, 0, carol());
-	let open_yes_orders = contract.get_open_orders(0, 1, carol());
+	let open_no_orders = contract.get_open_orders(0, 0);
+	let open_yes_orders = contract.get_open_orders(0, 1);
 	assert_eq!(open_no_orders.len(), 0);
 	assert_eq!(open_yes_orders.len(), 0);
-	let filled_no_orders = contract.get_filled_orders(0, 0, carol());
-	let filled_yes_orders = contract.get_filled_orders(0, 1, carol());
+	let filled_no_orders = contract.get_filled_orders(0, 0);
+	let filled_yes_orders = contract.get_filled_orders(0, 1);
 	assert_eq!(filled_no_orders.len(), 1);
 	assert_eq!(filled_yes_orders.len(), 2);
 }

--- a/src/markets/tests/binary_order_matching_tests.rs
+++ b/src/markets/tests/binary_order_matching_tests.rs
@@ -41,26 +41,3 @@ fn partial_binary_order_matching_test() {
 	assert_eq!(filled_no_orders.len(), 1);
 	assert_eq!(filled_yes_orders.len(), 2);
 }
-
-#[test]
-fn rounding_binary_order_matching_test() {
-	testing_env!(get_context(carol()));
-	let mut contract = Markets::default();
-	contract.claim_fdai();
-	contract.create_market("Hi!".to_string(), empty_string(), 2, outcome_tags(0), categories(), 100010101001010);
-	contract.place_order(0, 0, 8000, 80); // filled completely
-	contract.place_order(0, 1, 3000, 30); // filled @ 20 && 30
-	contract.place_order(0, 0, 2500, 70); 
-	contract.place_order(0, 1, 120, 30); 
-
-	let open_no_orders = contract.get_open_orders(0, 0, carol());
-	let open_yes_orders = contract.get_open_orders(0, 1, carol());
-	let filled_no_orders = contract.get_filled_orders(0, 0, carol());
-	let filled_yes_orders = contract.get_filled_orders(0, 1, carol());
-	
-	assert_eq!(open_no_orders.len(), 0);
-	assert_eq!(open_yes_orders.len(), 0);
-	assert_eq!(filled_no_orders.len(), 2);
-	assert_eq!(filled_yes_orders.len(), 2);
-
-}

--- a/src/markets/tests/binary_order_matching_tests.rs
+++ b/src/markets/tests/binary_order_matching_tests.rs
@@ -9,12 +9,12 @@ fn simplest_binary_order_matching_test() {
 	contract.place_order(0, 0, 5000, 50);
 	contract.place_order(0, 1, 5000, 50);
 
-	let mut open_no_orders = contract.get_open_orders(0, 0, carol());
-	let mut open_yes_orders = contract.get_open_orders(0, 1, carol());
+	let open_no_orders = contract.get_open_orders(0, 0, carol());
+	let open_yes_orders = contract.get_open_orders(0, 1, carol());
 	assert_eq!(open_no_orders.len(), 0);
 	assert_eq!(open_yes_orders.len(), 0);
-	let mut filled_no_orders = contract.get_filled_orders(0, 0, carol());
-	let mut filled_yes_orders = contract.get_filled_orders(0, 1, carol());
+	let filled_no_orders = contract.get_filled_orders(0, 0, carol());
+	let filled_yes_orders = contract.get_filled_orders(0, 1, carol());
 	assert_eq!(filled_no_orders.len(), 1);
 	assert_eq!(filled_yes_orders.len(), 1);
 }
@@ -32,12 +32,12 @@ fn partial_binary_order_matching_test() {
 	contract.place_order(0, 1, 2750, 50);
 	contract.place_order(0, 0, 7777, 50);
 
-	let mut open_no_orders = contract.get_open_orders(0, 0, carol());
-	let mut open_yes_orders = contract.get_open_orders(0, 1, carol());
+	let open_no_orders = contract.get_open_orders(0, 0, carol());
+	let open_yes_orders = contract.get_open_orders(0, 1, carol());
 	assert_eq!(open_no_orders.len(), 0);
 	assert_eq!(open_yes_orders.len(), 0);
-	let mut filled_no_orders = contract.get_filled_orders(0, 0, carol());
-	let mut filled_yes_orders = contract.get_filled_orders(0, 1, carol());
+	let filled_no_orders = contract.get_filled_orders(0, 0, carol());
+	let filled_yes_orders = contract.get_filled_orders(0, 1, carol());
 	assert_eq!(filled_no_orders.len(), 1);
 	assert_eq!(filled_yes_orders.len(), 2);
 }
@@ -53,10 +53,10 @@ fn rounding_binary_order_matching_test() {
 	contract.place_order(0, 0, 2500, 70); 
 	contract.place_order(0, 1, 120, 30); 
 
-	let mut open_no_orders = contract.get_open_orders(0, 0, carol());
-	let mut open_yes_orders = contract.get_open_orders(0, 1, carol());
-	let mut filled_no_orders = contract.get_filled_orders(0, 0, carol());
-	let mut filled_yes_orders = contract.get_filled_orders(0, 1, carol());
+	let open_no_orders = contract.get_open_orders(0, 0, carol());
+	let open_yes_orders = contract.get_open_orders(0, 1, carol());
+	let filled_no_orders = contract.get_filled_orders(0, 0, carol());
+	let filled_yes_orders = contract.get_filled_orders(0, 1, carol());
 	
 	assert_eq!(open_no_orders.len(), 0);
 	assert_eq!(open_yes_orders.len(), 0);

--- a/src/markets/tests/bst_tests.rs
+++ b/src/markets/tests/bst_tests.rs
@@ -26,50 +26,50 @@ fn test_bst_additions() {
 	let order_5 = open_orders.get(&5).unwrap();
 
 	// [0]
-	assert_eq!(order_0.parent, None);
-	assert_eq!(order_0.better_order_id, Some(2));
-	assert_eq!(order_0.worse_order_id, Some(1));
+	//assert_eq!(order_0.parent, None);
+	//assert_eq!(order_0.better_order_id, Some(2));
+	//assert_eq!(order_0.worse_order_id, Some(1));
 
 	//   [0]
 	//  /
 	// [1] <-
-	assert_eq!(order_1.parent, Some(order_0.id));
-	assert_eq!(order_1.better_order_id, Some(5));
-	assert_eq!(order_1.worse_order_id, None);
+	//assert_eq!(order_1.parent, Some(order_0.id));
+	//assert_eq!(order_1.better_order_id, Some(5));
+	//assert_eq!(order_1.worse_order_id, None);
 
 	//   [0]
 	//  /  \
 	// [1]  [2] <-
-	assert_eq!(order_2.parent, Some(order_0.id));
-	assert_eq!(order_2.better_order_id, Some(3));
-	assert_eq!(order_2.worse_order_id, Some(4));
+	//assert_eq!(order_2.parent, Some(order_0.id));
+	//assert_eq!(order_2.better_order_id, Some(3));
+	//assert_eq!(order_2.worse_order_id, Some(4));
 
 	//   [0]
 	//  /  \
 	// [1]  [2] 
 	//         \
 	//		   [3] <-
-	assert_eq!(order_3.parent, Some(2));
-	assert_eq!(order_3.better_order_id, None);
-	assert_eq!(order_3.worse_order_id, None);
+	//assert_eq!(order_3.parent, Some(2));
+	//assert_eq!(order_3.better_order_id, None);
+	//assert_eq!(order_3.worse_order_id, None);
 
 	//   [0]
 	//  /  \
 	// [1]  [2] 
 	//     /   \
 	//-> [4]   [3] 
-	assert_eq!(order_4.parent, Some(2));
-	assert_eq!(order_4.better_order_id, None);
-	assert_eq!(order_4.worse_order_id, Some(6));
+	//assert_eq!(order_4.parent, Some(2));
+	//assert_eq!(order_4.better_order_id, None);
+	//assert_eq!(order_4.worse_order_id, Some(6));
 
 	//   [0]
 	//  /     \
 	// [1]       [2] 
 	//    \     /   \
 	//  ->[5] [4]   [3] 
-	assert_eq!(order_5.parent, Some(1));
-	assert_eq!(order_5.better_order_id, None);
-	assert_eq!(order_5.worse_order_id, None);
+	//assert_eq!(order_5.parent, Some(1));
+	//assert_eq!(order_5.better_order_id, None);
+	//assert_eq!(order_5.worse_order_id, None);
 }	
 
 #[test]
@@ -88,25 +88,25 @@ fn test_bst_removal() {
 	contract.cancel_order(0, 0, 0);
 	contract.cancel_order(0, 0, 1);
 
-	let open_orders = &contract.get_market(0).orderbooks.get(&0).as_ref().unwrap().open_orders;
-	let order_2 = open_orders.get(&2).unwrap();
-	let order_3 = open_orders.get(&3).unwrap();
-	let order_4 = open_orders.get(&4).unwrap();
-	let order_5 = open_orders.get(&5).unwrap();
+	//let open_orders = &contract.get_market(0).orderbooks.get(&0).as_ref().unwrap().open_orders;
+	//let order_2 = open_orders.get(&2).unwrap();
+	//let order_3 = open_orders.get(&3).unwrap();
+	//let order_4 = open_orders.get(&4).unwrap();
+	//let order_5 = open_orders.get(&5).unwrap();
 
-	assert_eq!(order_2.parent, None);
-	assert_eq!(order_2.better_order_id, Some(3));
-	assert_eq!(order_2.worse_order_id, Some(4));
+	//assert_eq!(order_2.parent, None);
+	//assert_eq!(order_2.better_order_id, Some(3));
+	//assert_eq!(order_2.worse_order_id, Some(4));
 
-	assert_eq!(order_3.parent, Some(2));
-	assert_eq!(order_3.better_order_id, None);
-	assert_eq!(order_3.worse_order_id, None);
+	//assert_eq!(order_3.parent, Some(2));
+	//assert_eq!(order_3.better_order_id, None);
+	//assert_eq!(order_3.worse_order_id, None);
 	
-	assert_eq!(order_4.parent, Some(2));
-	assert_eq!(order_4.better_order_id, None);
-	assert_eq!(order_4.worse_order_id, Some(5));
+	//assert_eq!(order_4.parent, Some(2));
+	//assert_eq!(order_4.better_order_id, None);
+	//assert_eq!(order_4.worse_order_id, Some(5));
 
-	assert_eq!(order_5.parent, Some(4));
-	assert_eq!(order_5.better_order_id, None);
-	assert_eq!(order_5.worse_order_id, None);
+	//assert_eq!(order_5.parent, Some(4));
+	//assert_eq!(order_5.better_order_id, None);
+	//assert_eq!(order_5.worse_order_id, None);
 }

--- a/src/markets/tests/categorical_market_tests.rs
+++ b/src/markets/tests/categorical_market_tests.rs
@@ -11,17 +11,25 @@ fn test_categorical_market_matches() {
 	contract.place_order(0, 1, 5000000000000000000, 65);
 	contract.place_order(0, 2, 5000000000000000000, 5);
 	contract.place_order(0, 0, 100000000000000000, 31);
-	
-	let mut open_0_orders = contract.get_open_orders(0, 0, carol());
-	let mut open_1_orders = contract.get_open_orders(0, 1, carol());
-	let mut open_2_orders = contract.get_open_orders(0, 2, carol());
-	let mut filled_0_orders = contract.get_filled_orders(0, 0, carol());
-	let mut filled_1_orders = contract.get_filled_orders(0, 1, carol());
-	let mut filled_2_orders = contract.get_filled_orders(0, 2, carol());
+
+	let open_0_orders = contract.get_open_orders(0, 0, carol());
+    let open_1_orders = contract.get_open_orders(0, 1, carol());
+    let open_2_orders = contract.get_open_orders(0, 2, carol());
+    let filled_0_orders = contract.get_filled_orders(0, 0, carol());
+    let filled_1_orders = contract.get_filled_orders(0, 1, carol());
+    let filled_2_orders = contract.get_filled_orders(0, 2, carol());
+
 
 	// // uncomment for orderbook state check
 	// println!("{:?}", open_0_orders);
 	// println!("{:?}", open_1_orders);
 	// println!("{:?}", open_2_orders);
 
+	// assertions for the orderbook lengths
+	assert_eq!(open_0_orders.len(), 2);
+	assert_eq!(open_1_orders.len(), 1);
+	assert_eq!(open_2_orders.len(), 1);
+	assert_eq!(filled_0_orders.len(), 0);
+	assert_eq!(filled_1_orders.len(), 0);
+	assert_eq!(filled_2_orders.len(), 0);
 }

--- a/src/markets/tests/categorical_market_tests.rs
+++ b/src/markets/tests/categorical_market_tests.rs
@@ -7,29 +7,32 @@ fn test_categorical_market_matches() {
 	contract.claim_fdai();
 	contract.create_market("Hi!".to_string(), empty_string(), 3, outcome_tags(3), categories(), 100010101001010);
 
-	contract.place_order(0, 0, 5000000000000000000, 25);
-	contract.place_order(0, 1, 5000000000000000000, 65);
-	contract.place_order(0, 2, 5000000000000000000, 5);
-	contract.place_order(0, 0, 100000000000000000, 31);
+	contract.place_order(0, 0, 50000, 25);
+	contract.place_order(0, 1, 50000, 65);
+	contract.place_order(0, 2, 50000, 5);
+	contract.place_order(0, 0, 1000, 31);
 
-	let open_0_orders = contract.get_open_orders(0, 0, carol());
-    let open_1_orders = contract.get_open_orders(0, 1, carol());
-    let open_2_orders = contract.get_open_orders(0, 2, carol());
-    let filled_0_orders = contract.get_filled_orders(0, 0, carol());
-    let filled_1_orders = contract.get_filled_orders(0, 1, carol());
-    let filled_2_orders = contract.get_filled_orders(0, 2, carol());
+	let open_0_orders = contract.get_open_orders(0, 0);
+    let open_1_orders = contract.get_open_orders(0, 1);
+    let open_2_orders = contract.get_open_orders(0, 2);
+    let filled_0_orders = contract.get_filled_orders(0, 0);
+    let filled_1_orders = contract.get_filled_orders(0, 1);
+    let filled_2_orders = contract.get_filled_orders(0, 2);
 
 
 	// // uncomment for orderbook state check
 	// println!("{:?}", open_0_orders);
 	// println!("{:?}", open_1_orders);
 	// println!("{:?}", open_2_orders);
+	// println!("{:?}", filled_0_orders);
+	// println!("{:?}", filled_1_orders);
+	// println!("{:?}", filled_2_orders);
 
 	// assertions for the orderbook lengths
-	assert_eq!(open_0_orders.len(), 2);
+	assert_eq!(open_0_orders.len(), 1);
 	assert_eq!(open_1_orders.len(), 1);
 	assert_eq!(open_2_orders.len(), 1);
-	assert_eq!(filled_0_orders.len(), 0);
+	assert_eq!(filled_0_orders.len(), 1);
 	assert_eq!(filled_1_orders.len(), 0);
 	assert_eq!(filled_2_orders.len(), 0);
 }

--- a/src/markets/tests/claim_earnings_tests.rs
+++ b/src/markets/tests/claim_earnings_tests.rs
@@ -7,14 +7,13 @@ fn test_payout() {
 	contract.claim_fdai();
 	contract.create_market("Hi!".to_string(), empty_string(), 4, outcome_tags(4), categories(), 100010101001010);
 
-	contract.place_order(0, 0, 30000, 70);
+	contract.place_order(0, 0, 10000, 70);
 	contract.place_order(0, 3, 1000, 10); 
 	
 	testing_env!(get_context(alice()));
 	contract.claim_fdai();
 	contract.place_order(0, 1, 1000, 10); 
 	contract.place_order(0, 2, 1000, 10); 
-	
 	
 	testing_env!(get_context(carol()));
 	contract.resolute(0, Some(0));
@@ -25,15 +24,6 @@ fn test_payout() {
 	let initial_balance_carol = contract.get_fdai_balance(carol());
 	let initial_balance_alice = contract.get_fdai_balance(alice());
 	
-	// // print logs
-	// println!("____________CLAIMABLE CAROL____________");
-	// println!("initially claimable: {}", initially_claimable_carol);
-	// println!("initial fdai balance: {}", initial_balance_carol);
-	// println!("");
-	// println!("____________CLAIMABLE ALICE____________");
-	// println!("initially claimable: {}", initially_claimable_alice);
-	// println!("initial fdai balance: {}", initial_balance_alice);
-	// println!("");
 	contract.claim_earnings(0, carol());
 	testing_env!(get_context(alice()));
 	contract.claim_earnings(0, alice());
@@ -44,19 +34,9 @@ fn test_payout() {
 	let updated_balance_carol = contract.get_fdai_balance(carol());
 	let updated_balance_alice = contract.get_fdai_balance(alice());
 
-	// // print logs
-	// println!("____________AFTER CLAIM CAROL____________");
-	// println!("updated claimable: {}", claimable_after_claim_carol);
-	// println!("updated fdai balance: {}", updated_balance_carol);
-	// println!("");
-	// println!("____________AFTER CLAIM ALICE____________");
-	// println!("updated claimable: {}", claimable_after_claim_alice);
-	// println!("updated fdai balance: {}", updated_balance_alice);
-	// println!("");
-	
-	assert_eq!(claimable_after_claim_carol, 0);
-	assert_eq!(claimable_after_claim_alice, 0);
 	assert_eq!(updated_balance_carol, initially_claimable_carol + initial_balance_carol);
 	assert_eq!(updated_balance_alice, initially_claimable_alice + initial_balance_alice);
+	assert_eq!(claimable_after_claim_carol, 0);
+	assert_eq!(claimable_after_claim_alice, 0);
 	
 }

--- a/src/markets/tests/market_depth_tests.rs
+++ b/src/markets/tests/market_depth_tests.rs
@@ -1,0 +1,34 @@
+use super::*;
+
+#[test]
+fn test_valid_market_depth() {
+	testing_env!(get_context(carol()));
+	let mut contract = Markets::default();
+	contract.claim_fdai();
+	contract.create_market("Hi!".to_string(), empty_string(), 4, outcome_tags(4), categories(), 100010101001010);
+
+	contract.place_order(0, 0, 6000, 60);
+
+	testing_env!(get_context(alice()));
+	contract.claim_fdai();
+	contract.place_order(0, 1, 1000, 10);
+	contract.place_order(0, 2, 1000, 23);
+	contract.place_order(0, 2, 2000, 22);
+
+    let market_0 = contract.active_markets.get(&0).unwrap();
+    let orderbook_0 = market_0.orderbooks.get(&0).unwrap();
+    let mut yes_market_price = contract.get_market_price(0, 0);
+    let depth_0 = orderbook_0.get_liquidity(1000, 75);
+
+	let market_1 = contract.active_markets.get(&0).unwrap();
+    let orderbook_1 = market_1.orderbooks.get(&1).unwrap();
+    let depth_1 = orderbook_1.get_liquidity(1000, 11);
+
+    let market_2 = contract.active_markets.get(&0).unwrap();
+    let orderbook_2 = market_2.orderbooks.get(&2).unwrap();
+    let depth_2 = orderbook_2.get_liquidity(5000, 24);
+
+    assert_eq!(depth_0, (60 , 16, 960));
+	assert_eq!(depth_1, (10, 100, 1000));
+	assert_eq!(depth_2, (23, 133, 2969));
+}

--- a/src/markets/tests/market_order_tests.rs
+++ b/src/markets/tests/market_order_tests.rs
@@ -11,23 +11,24 @@ fn test_market_orders() {
 	contract.place_order(0, 1, 5000, 50); // 0 
 	contract.place_order(0, 1, 5000, 50); // 1
 
-	let mut yes_market_price = contract.get_market_price(0, 1);
+	let mut yes_market_price = contract.get_market_price(0, 0);
 	assert_eq!(yes_market_price, 50);
 
 	contract.place_order(0, 1, 5000, 60); // 2
-	yes_market_price= contract.get_market_price(0, 1);
+	yes_market_price= contract.get_market_price(0, 0);
+	println!("{}", yes_market_price);
 	assert_eq!(yes_market_price, 40);
 
-	contract.cancel_order(0, 1, 2);
-	yes_market_price = contract.get_market_price(0, 1);
+	contract.cancel_order(0, 1, 2, 60);
+	yes_market_price = contract.get_market_price(0, 0);
 	assert_eq!(yes_market_price, 50);
 
-	contract.cancel_order(0, 1, 1);
-	yes_market_price = contract.get_market_price(0, 1);
+	contract.cancel_order(0, 1, 1, 50);
+	yes_market_price = contract.get_market_price(0, 0);
 	assert_eq!(yes_market_price, 50);
 	
-	contract.cancel_order(0, 1, 0);
-	yes_market_price = contract.get_market_price(0, 1);
+	contract.cancel_order(0, 1, 0, 50);
+	yes_market_price = contract.get_market_price(0, 0);
 	assert_eq!(yes_market_price, 100);
 
 }

--- a/src/markets/tests/market_order_tests.rs
+++ b/src/markets/tests/market_order_tests.rs
@@ -11,23 +11,23 @@ fn test_market_orders() {
 	contract.place_order(0, 1, 5000, 50); // 0 
 	contract.place_order(0, 1, 5000, 50); // 1
 
-	let mut yes_market_order_id = contract.get_market_order(0, 1);
-	assert_eq!(yes_market_order_id, Some(0));
+	let mut yes_market_price = contract.get_market_price(0, 1);
+	assert_eq!(yes_market_price, 50);
 
 	contract.place_order(0, 1, 5000, 60); // 2
-	yes_market_order_id = contract.get_market_order(0, 1);
-	assert_eq!(yes_market_order_id, Some(2));
+	yes_market_price= contract.get_market_price(0, 1);
+	assert_eq!(yes_market_price, 40);
 
 	contract.cancel_order(0, 1, 2);
-	yes_market_order_id = contract.get_market_order(0, 1);
-	assert_eq!(yes_market_order_id, Some(1));
+	yes_market_price = contract.get_market_price(0, 1);
+	assert_eq!(yes_market_price, 50);
 
 	contract.cancel_order(0, 1, 1);
-	yes_market_order_id = contract.get_market_order(0, 1);
-	assert_eq!(yes_market_order_id, Some(0));
+	yes_market_price = contract.get_market_price(0, 1);
+	assert_eq!(yes_market_price, 50);
 	
 	contract.cancel_order(0, 1, 0);
-	yes_market_order_id = contract.get_market_order(0, 1);
-	assert_eq!(yes_market_order_id, None);
+	yes_market_price = contract.get_market_price(0, 1);
+	assert_eq!(yes_market_price, 100);
 
 }

--- a/src/markets/tests/market_order_tests.rs
+++ b/src/markets/tests/market_order_tests.rs
@@ -16,18 +16,17 @@ fn test_market_orders() {
 
 	contract.place_order(0, 1, 5000, 60); // 2
 	yes_market_price= contract.get_market_price(0, 0);
-	println!("{}", yes_market_price);
 	assert_eq!(yes_market_price, 40);
 
-	contract.cancel_order(0, 1, 2, 60);
+	contract.cancel_order(0, 1, 2);
 	yes_market_price = contract.get_market_price(0, 0);
 	assert_eq!(yes_market_price, 50);
 
-	contract.cancel_order(0, 1, 1, 50);
+	contract.cancel_order(0, 1, 1);
 	yes_market_price = contract.get_market_price(0, 0);
 	assert_eq!(yes_market_price, 50);
 	
-	contract.cancel_order(0, 1, 0, 50);
+	contract.cancel_order(0, 1, 0);
 	yes_market_price = contract.get_market_price(0, 0);
 	assert_eq!(yes_market_price, 100);
 

--- a/src/markets/tests/market_resolution_tests.rs
+++ b/src/markets/tests/market_resolution_tests.rs
@@ -8,7 +8,7 @@ fn test_invalid_market_payout_calc() {
 	contract.create_market("Hi!".to_string(), empty_string(), 4, outcome_tags(4), categories(), 100010101001010);
 
 	let rounded_10k_at_70 = (10000 / 70) * 70;
-	let mut amount_filled_after_cancel = 10000 - 2840;
+	let amount_filled_after_cancel = 10000 - 2840;
 	let expected_carol_balance = (2 * rounded_10k_at_70 + 3 * 10000) - amount_filled_after_cancel;
 	contract.place_order(0, 0, 10000, 70);
 	contract.place_order(0, 0, 10000, 70);
@@ -36,12 +36,12 @@ fn test_invalid_market_payout_calc() {
 	assert_eq!(claimable_alice, expected_alice_balance);
 
 	// Orderbook length assertions
-	let mut open_0_orders = contract.get_open_orders(0, 0, carol());
-	let mut open_1_orders = contract.get_open_orders(0, 1, carol());
-	let mut open_2_orders = contract.get_open_orders(0, 2, carol());
-	let mut filled_0_orders = contract.get_filled_orders(0, 0, carol());
-	let mut filled_1_orders = contract.get_filled_orders(0, 1, carol());
-	let mut filled_2_orders = contract.get_filled_orders(0, 2, carol());
+	let open_0_orders = contract.get_open_orders(0, 0, carol());
+	let open_1_orders = contract.get_open_orders(0, 1, carol());
+	let open_2_orders = contract.get_open_orders(0, 2, carol());
+	let filled_0_orders = contract.get_filled_orders(0, 0, carol());
+	let filled_1_orders = contract.get_filled_orders(0, 1, carol());
+	let filled_2_orders = contract.get_filled_orders(0, 2, carol());
 
 	// // debugging logs
 	// println!("open 0 {:?}", open_0_orders);
@@ -53,7 +53,7 @@ fn test_invalid_market_payout_calc() {
 	// println!("filled 2 {:?}", filled_2_orders);
 
 	assert_eq!(open_0_orders.len(), 0);
-	assert_eq!(filled_0_orders.len(),3);
+	assert_eq!(filled_0_orders.len(), 3);
 
 	assert_eq!(open_1_orders.len(), 1);
 	assert_eq!(filled_1_orders.len(), 2);
@@ -81,12 +81,12 @@ fn test_valid_market_payout_calc() {
 	testing_env!(get_context(carol()));
 	contract.resolute(0, Some(1));
 
-	let mut open_0_orders = contract.get_open_orders(0, 0, carol());
-	let mut open_1_orders = contract.get_open_orders(0, 1, carol());
-	let mut open_2_orders = contract.get_open_orders(0, 2, carol());
-	let mut filled_0_orders = contract.get_filled_orders(0, 0, carol());
-	let mut filled_1_orders = contract.get_filled_orders(0, 1, carol());
-	let mut filled_2_orders = contract.get_filled_orders(0, 2, carol());
+	let open_0_orders = contract.get_open_orders(0, 0, carol());
+	let open_1_orders = contract.get_open_orders(0, 1, carol());
+	let open_2_orders = contract.get_open_orders(0, 2, carol());
+	let filled_0_orders = contract.get_filled_orders(0, 0, carol());
+	let filled_1_orders = contract.get_filled_orders(0, 1, carol());
+	let filled_2_orders = contract.get_filled_orders(0, 2, carol());
 
 	// // uncomment for orderbook state check
 	// println!("open {:?}", 	open_0_orders);

--- a/src/markets/tests/market_resolution_tests.rs
+++ b/src/markets/tests/market_resolution_tests.rs
@@ -7,60 +7,45 @@ fn test_invalid_market_payout_calc() {
 	contract.claim_fdai();
 	contract.create_market("Hi!".to_string(), empty_string(), 4, outcome_tags(4), categories(), 100010101001010);
 
-	let rounded_10k_at_70 = (10000 / 70) * 70;
-	let amount_filled_after_cancel = 10000 - 2840;
-	let expected_carol_balance = (2 * rounded_10k_at_70 + 3 * 10000) - amount_filled_after_cancel;
-	contract.place_order(0, 0, 10000, 70);
-	contract.place_order(0, 0, 10000, 70);
-	contract.place_order(0, 1, 10000, 10); 
-	contract.place_order(0, 2, 10000, 10); 
-	contract.place_order(0, 3, 10000, 10);
+	contract.place_order(0, 0, 7000, 70);
+	contract.place_order(0, 1, 1000, 10); 
+	contract.place_order(0, 2, 1000, 10); 
+	contract.place_order(0, 3, 1000, 10);
 	
 	testing_env!(get_context(alice()));
 	contract.claim_fdai();
 
-	let rounded_10k_at_60 = (10000 / 60) * 60;
-	contract.place_order(0, 0, 10000, 60);
-	contract.place_order(0, 1, 10000, 20); 
-	contract.place_order(0, 1, 10000, 20); 
-	
-	let expected_alice_balance = (1 * rounded_10k_at_60 + 2 * 10000) - (10000 - 3320);
-	contract.cancel_order(0,1, 1);
+	contract.place_order(0, 0, 6000, 60);
+	contract.place_order(0, 1, 2000, 20); 
+	contract.place_order(0, 2, 2000, 20); 
 
 	testing_env!(get_context(carol()));
-	contract.cancel_order(0,1, 0);
 	contract.resolute(0, None);
 	let claimable_carol = contract.get_claimable(0, carol());
 	let claimable_alice = contract.get_claimable(0, alice());
-	assert_eq!(claimable_carol, expected_carol_balance);
-	assert_eq!(claimable_alice, expected_alice_balance);
+	assert_eq!(claimable_carol, 10000);
+	assert_eq!(claimable_alice, 10000);
 
-	// Orderbook length assertions
-	let open_0_orders = contract.get_open_orders(0, 0, carol());
-	let open_1_orders = contract.get_open_orders(0, 1, carol());
-	let open_2_orders = contract.get_open_orders(0, 2, carol());
-	let filled_0_orders = contract.get_filled_orders(0, 0, carol());
-	let filled_1_orders = contract.get_filled_orders(0, 1, carol());
-	let filled_2_orders = contract.get_filled_orders(0, 2, carol());
+	let open_orders_0 = contract.get_open_orders(0, 0);
+	let open_orders_1 = contract.get_open_orders(0, 1);
+	let open_orders_2 = contract.get_open_orders(0, 2);
+	let open_orders_3 = contract.get_open_orders(0, 3);
 
-	// // debugging logs
-	// println!("open 0 {:?}", open_0_orders);
-	// println!("open 1 {:?}", open_1_orders);
-	// println!("open 2 {:?}", open_2_orders);
+	assert_eq!(open_orders_0.len(), 0);
+	assert_eq!(open_orders_1.len(), 0);
+	assert_eq!(open_orders_2.len(), 0);
+	assert_eq!(open_orders_3.len(), 0);
 
-	// println!("filled 0 {:?}", filled_0_orders);
-	// println!("filled 1 {:?}", filled_1_orders);
-	// println!("filled 2 {:?}", filled_2_orders);
+	let filled_orders_0 = contract.get_filled_orders(0, 0);
+	let filled_orders_1 = contract.get_filled_orders(0, 1);
+	let filled_orders_2 = contract.get_filled_orders(0, 2);
+	let filled_orders_3 = contract.get_filled_orders(0, 3);
 
-	assert_eq!(open_0_orders.len(), 0);
-	assert_eq!(filled_0_orders.len(), 3);
+	assert_eq!(filled_orders_0.len(), 2);
+	assert_eq!(filled_orders_1.len(), 2);
+	assert_eq!(filled_orders_2.len(), 2);
+	assert_eq!(filled_orders_3.len(), 1);
 
-	assert_eq!(open_1_orders.len(), 1);
-	assert_eq!(filled_1_orders.len(), 2);
-
-	assert_eq!(open_2_orders.len(), 1);
-	assert_eq!(filled_2_orders.len(), 0);
-	
 }
 
 #[test]
@@ -70,7 +55,7 @@ fn test_valid_market_payout_calc() {
 	contract.claim_fdai();
 	contract.create_market("Hi!".to_string(), empty_string(), 4, outcome_tags(4), categories(), 100010101001010);
 
-	contract.place_order(0, 0, 30000, 70);
+	contract.place_order(0, 0, 7000, 70);
 	
 	testing_env!(get_context(alice()));
 	contract.claim_fdai();
@@ -81,22 +66,26 @@ fn test_valid_market_payout_calc() {
 	testing_env!(get_context(carol()));
 	contract.resolute(0, Some(1));
 
-	let open_0_orders = contract.get_open_orders(0, 0, carol());
-	let open_1_orders = contract.get_open_orders(0, 1, carol());
-	let open_2_orders = contract.get_open_orders(0, 2, carol());
-	let filled_0_orders = contract.get_filled_orders(0, 0, carol());
-	let filled_1_orders = contract.get_filled_orders(0, 1, carol());
-	let filled_2_orders = contract.get_filled_orders(0, 2, carol());
+	let open_orders_0 = contract.get_open_orders(0, 0);
+	let open_orders_1 = contract.get_open_orders(0, 1);
+	let open_orders_2 = contract.get_open_orders(0, 2);
 
-	// // uncomment for orderbook state check
-	// println!("open {:?}", 	open_0_orders);
-	// println!("open {:?}", 	open_1_orders);
-	// println!("open {:?}", 	open_2_orders);
+	assert_eq!(open_orders_0.len(), 0);
+	assert_eq!(open_orders_1.len(), 0);
+	assert_eq!(open_orders_2.len(), 0);
 
-	// println!("filled {:?}", filled_0_orders);
-	// println!("filled {:?}", filled_1_orders);
-	// println!("filled {:?}", filled_2_orders);
+	let filled_orders_0 = contract.get_filled_orders(0, 0);
+	let filled_orders_1 = contract.get_filled_orders(0, 1);
+	let filled_orders_2 = contract.get_filled_orders(0, 2);
+
+	assert_eq!(filled_orders_0.len(), 1);
+	assert_eq!(filled_orders_1.len(), 1);
+	assert_eq!(filled_orders_2.len(), 1);
+
 
 	let claimable_carol = contract.get_claimable(0, carol());
 	let claimable_alice = contract.get_claimable(0, alice());
+
+	assert_eq!(claimable_carol, 0);
+	assert_eq!(claimable_alice, 10000);
 }


### PR DESCRIPTION
Orderbook method that allows users to query for the liquidity available to them given a spend limit and max_price they are willing to pay. 

Specifically, returns the max share price required to complete the order, the number of shares they will receive in return for their spend, and the total amount they will spend on the order.