### PR TITLE
Mike/logging correct naming

### DIFF
--- a/src/markets/tests/categorical_market_tests.rs
+++ b/src/markets/tests/categorical_market_tests.rs
@@ -24,7 +24,7 @@ fn test_categorical_market_automated_matcher() {
     accounts[0].token_init_new(runtime, accounts[0].get_account_id().to_string(), 10000000000000000).unwrap();
 
     // Call claim_fdai, create market
-    accounts[0].claim_fdai(runtime).unwrap();
+    println!("debug {:#?}", accounts[0].claim_fdai(runtime).unwrap());
 
     accounts[0].get_fdai_metrics(runtime);
 

--- a/src/markets/tests/utils.rs
+++ b/src/markets/tests/utils.rs
@@ -239,7 +239,7 @@ impl ExternalUser {
             let data: Vec<serde_json::Value> = serde_json::from_slice(fdai_metrics.as_slice()).unwrap();
             println!("{:?}", data);
             // let fdai_metrics_vec: Vec<(u128, u128, u128, u64)> = serde_json::from_value(serde_json::to_value(data).unwrap()).unwrap();
-            let fdai_metrics_vec: Vec<u8> = serde_json::from_value(serde_json::to_value(data).unwrap()).unwrap();
+            let fdai_metrics_vec: Vec<u128> = serde_json::from_value(serde_json::to_value(data).unwrap()).unwrap();
             println!("{:?}", fdai_metrics_vec);
             return 1;
         }


### PR DESCRIPTION
Jumped on a call with Eugene who helped explain some of this. So the best way to be able to debug is to have claim_fdai return a promise. Then, you can see we are able to debug it better.
With the "simulation testing" approach we're using here (as opposed to unit testing with the `VMContext` you've probably seen elsewhere) we'll need to use `env::log` instead of `println!` in order to make sure it's working.
Also, when we were using this `Promise` approach we kept getting `MethodNotFound` and dug into it until we realized that `update_fdai_metrics` needed to be `update_fdai_metrics_claim` as you see here. That is a big part of why this was blocked.