### PR TITLE
use U128 when deploying and initializing fun token, env logs

### DIFF
--- a/src/markets/tests/categorical_market_tests.rs
+++ b/src/markets/tests/categorical_market_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::markets::tests::utils::{init_markets_contract, ExternalUser, ntoy};
+use near_sdk::json_types::U128;
 
 #[test]
 fn test_categorical_market_automated_matcher() {
@@ -21,10 +22,10 @@ fn test_categorical_market_automated_matcher() {
         accounts.push(acc);
     }
 
-    accounts[0].token_init_new(runtime, accounts[0].get_account_id().to_string(), 10000000000000000).unwrap();
+    accounts[0].token_deploy_call_new(runtime, accounts[0].get_account_id().to_string(),  U128(10000000000000000)).unwrap();
 
     // Call claim_fdai, create market
-    println!("debug {:#?}", accounts[0].claim_fdai(runtime).unwrap());
+    println!("debug accounts[0] {:#?}", accounts[0].claim_fdai(runtime).unwrap());
 
     accounts[0].get_fdai_metrics(runtime);
 
@@ -39,7 +40,7 @@ fn test_categorical_market_automated_matcher() {
     accounts[0].place_order(runtime, 0, 1, 5000, 50);
 
     // alice fills all orders
-    accounts[1].claim_fdai(runtime).unwrap();
+    println!("debug accounts[1] {:#?}", accounts[1].claim_fdai(runtime).unwrap());
     accounts[1].place_order(runtime, 0, 2, 3500, 25);
 
     let open_0_orders = accounts[1].get_open_orders(runtime, 0, 0);

--- a/src/markets/tests/utils.rs
+++ b/src/markets/tests/utils.rs
@@ -13,6 +13,8 @@ use near_primitives::{
 use std::collections::{HashMap};
 
 use serde_json::json;
+use near_sdk::json_types::U128;
+
 type TxResult = Result<ExecutionOutcome, ExecutionOutcome>;
 
 lazy_static::lazy_static! {
@@ -64,25 +66,23 @@ impl ExternalUser {
         return ans;
     }
 
-    pub fn token_init_new(&self, runtime: &mut RuntimeStandalone, from: String, amount: u64) -> TxResult {
+    pub fn token_deploy_call_new(&self, runtime: &mut RuntimeStandalone, account: String, total_supply: U128) -> TxResult {
+        // let args = json!({}).to_string().as_bytes().to_vec();
         let args = json!({
-            "from": from,
-            "amount": amount,
-        })
-            .to_string()
-            .as_bytes()
-            .to_vec();
+            "owner_id": account,
+            "total_supply": total_supply
+        }).to_string().as_bytes().to_vec();
 
         let tx = self
-            .new_tx(runtime, "flux-tests".to_string())
-            .function_call("deploy_fungible_token".into(), args, 10000000000000000, 0)
+            .new_tx(runtime, account)
+            // .create_account()
+            // .transfer(99994508400000000000000000)
+            .deploy_contract(FUNGIBLE_TOKEN_BYTES.to_vec())
+            .function_call("new".into(), args, 10000000000000000, 0)
             .sign(&self.signer);
-
         let res = runtime.resolve_tx(tx).unwrap();
         runtime.process_all().unwrap();
         let ans = outcome_into_result(res);
-        //println!("token contract deploying");
-        //println!("{:?}", ans);
         return ans;
     }
 


### PR DESCRIPTION
A couple of things that I noticed here. The fungible token uses `U128` for `get_balance` as shown here:
https://github.com/near/near-sdk-rs/blob/master/examples/fungible-token/src/lib.rs#L185

So I added that where needed.
As mentioned in Telegram, I found that the RuntimeStandalone *will* print logs from `env::log` but it may not print all of them if it's chained. The best way that I found to debug remove all the bottom `.then(…` calls. Then build and test (remember that with simulation tests it's actually running on the .wasm file so you have to build and then test) and look for results. Add a `.then(…` rinse and repeat.

In the process of doing this, I found that the fungible token contract wasn't initialized, so I redid the method a bit until that error disappeared because it was deployed and initialized properly.

Notice the `.0` here, which is a way to get a `U128` into a `u128` so you can use it for comparison operators and whatnot.

This is something to work on, but I left it here.
`SINGLE_CALL_GAS * 3`
I got the out of gas error and hit it with a hammer by using this.

When I was on the phone with Eugene this morning he thought that chaining those events in `.then` was an odd approach and he suggested only using the `.then` pattern when it's making an external cross-contract call, like when it's checking the balance from the fungible token contract.